### PR TITLE
do not set reserved tags on EC2 instances

### DIFF
--- a/tests/unit/set_instance_tags/test_add_owner_email_tag.py
+++ b/tests/unit/set_instance_tags/test_add_owner_email_tag.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 
 from set_instance_tags import app

--- a/tests/unit/set_instance_tags/test_filter_tags.py
+++ b/tests/unit/set_instance_tags/test_filter_tags.py
@@ -1,0 +1,29 @@
+import unittest
+from set_instance_tags import app
+
+
+class TestFilterTags(unittest.TestCase):
+
+  def test_filter_tags(self):
+    full_tags = [
+      {
+        "Key": "Department",
+        "ResourceId": "i-0f08b4ff6872c9786",
+        "ResourceType": "instance",
+        "Value": "Platform"
+      },
+      {
+        "Key": "aws:cloudformation:stack-id",
+        "ResourceId": "i-0f08b4ff6872c9786",
+        "ResourceType": "instance",
+        "Value": "arn:aws:cloudformation:us-east-1:465877038949:stack/SC-465877038949-pp-5ydwosuynbtpq/26318a30-f214-11ea-bce0-0e706f74ed45"
+      }
+    ]
+    filtered_tags = [
+      {
+        "Key": "Department",
+        "Value": "Platform"
+      }
+    ]
+    tags = app.filter_tags(full_tags)
+    self.assertEqual(tags, filtered_tags)

--- a/tests/unit/set_instance_tags/test_get_instance_tags.py
+++ b/tests/unit/set_instance_tags/test_get_instance_tags.py
@@ -25,11 +25,7 @@ class TestGetInstanceTags(unittest.TestCase):
       app.get_ec2_client = MagicMock(return_value=ec2)
       valid_instance_id ='some_reasonable_instance_id'
       result = app.get_instance_tags(valid_instance_id)
-      formatted_tags = [
-        {'Key': 'heresatag', 'Value': 'heresatagvalue'},
-        {'Key': 'theresatag', 'Value': 'theresatagvalue'}
-      ]
-      self.assertEqual(formatted_tags, result)
+      self.assertEqual(tags, result)
 
 
   def test_invalid_instance(self):

--- a/tests/unit/set_instance_tags/test_handler.py
+++ b/tests/unit/set_instance_tags/test_handler.py
@@ -1,9 +1,7 @@
-import json
 import unittest
 from unittest.mock import MagicMock, patch
 
 import boto3
-import botocore
 from botocore.stub import Stubber
 
 from set_instance_tags import app
@@ -18,9 +16,10 @@ class TestHandler(unittest.TestCase):
       patch('set_instance_tags.app.get_instance_tags') as get_mock, \
       patch('set_instance_tags.app.get_principal_id') as arn_mock, \
       patch('set_instance_tags.app.get_synapse_email') as syn_mock, \
-      patch('set_instance_tags.app.add_owner_email_tag') as tags_mock:
+      patch('set_instance_tags.app.add_owner_email_tag') as tags_mock, \
+      patch('set_instance_tags.app.filter_tags') as filter_mock:
         name_mock.return_value = 'some-improbable-instance-id'
-        tags_mock.return_value = [{ 'Key': 'OwnerEmail', 'Value': 'janedoe@synapse.org' }]
+        filter_mock.return_value = [{ 'Key': 'OwnerEmail', 'Value': 'janedoe@synapse.org' }]
         stubber.add_response(
           method='create_tags',
           service_response={
@@ -41,9 +40,10 @@ class TestHandler(unittest.TestCase):
       patch('set_instance_tags.app.get_instance_tags') as get_mock, \
       patch('set_instance_tags.app.get_principal_id') as arn_mock, \
       patch('set_instance_tags.app.get_synapse_email') as syn_mock, \
-      patch('set_instance_tags.app.add_owner_email_tag') as tags_mock:
+      patch('set_instance_tags.app.add_owner_email_tag') as tags_mock, \
+      patch('set_instance_tags.app.filter_tags') as filter_mock:
         name_mock.return_value = 'some-improbable-instance-id'
-        tags_mock.return_value = [{ 'Key': 'OwnerEmail', 'Value': 'janedoe@synapse.org' }]
+        filter_mock.return_value = [{ 'Key': 'OwnerEmail', 'Value': 'janedoe@synapse.org' }]
         stubber.add_client_error(
         method='get_instance_tagging',
         service_error_code='NoSuchInstance',


### PR DESCRIPTION
* We cannot apply tags with keys starting with string 'aws:' because
  those are reserved tags[1]. Only AWS can apply those tags.
* Refactor to filter tags right before applying instead of on
  describe tags.

[1] https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html