### PR TITLE
exclude userProfile data from tagging

### DIFF
--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -5,6 +5,10 @@ import boto3
 import os
 
 SYNAPSE_TAG_PREFIX = 'synapse'
+SYNAPSE_USER_PROFILE_EXCLUDES = [
+  "createdOn", "etag", "summary", "profilePicureFileHandleId", "url",
+  "notificationSettings", "preferences"
+]
 
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
@@ -78,16 +82,16 @@ def get_synapse_user_team_id(synapse_id, team_ids):
 
   return None
 
-def get_synapse_user_profile_tags(user_profile, ignore_keys=["createdOn"]):
+def get_synapse_user_profile_tags(user_profile, excludes=SYNAPSE_USER_PROFILE_EXCLUDES):
   '''Derive synapse tags from synapse user profile data
   :param user_profile: the synapse user profile info
-  :param ignore_keys: the keys from the user profile to ignore
-         Note - no email tags are returned if userName is ignored
+  :param excludes: the list of Synapse userProfile data to exclude from tagging
+         Note - no email tags are returned if userName is excluded
   :return a list containing a dictionary of tags
   '''
   tags = []
   for key, value in user_profile.items():
-    if key in ignore_keys:
+    if key in excludes:
       continue
 
     # derive synapse email tag based on userName

--- a/tests/unit/utils/test_get_synapse_user_profile_tags.py
+++ b/tests/unit/utils/test_get_synapse_user_profile_tags.py
@@ -13,7 +13,7 @@ TEST_USER_PROFILE = {
 
 class TestGetSynapseUserProfileTags(unittest.TestCase):
 
-  def test_happy_default_ignore(self):
+  def test_happy_default_exclude(self):
     result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE)
     expected = [
         {'Key': 'synapse:firstName', 'Value': 'Joe'},
@@ -26,7 +26,7 @@ class TestGetSynapseUserProfileTags(unittest.TestCase):
     ]
     self.assertListEqual(result, expected)
 
-  def test_happy_mulitple_ignores(self):
+  def test_happy_mulitple_excludes(self):
     result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE,
                                                ["createdOn","company","firstName","lastName"])
     expected = [
@@ -37,7 +37,7 @@ class TestGetSynapseUserProfileTags(unittest.TestCase):
     ]
     self.assertListEqual(result, expected)
 
-  def test_happy_ignores_user_name(self):
+  def test_happy_excludes_user_name(self):
     result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE, ["userName"])
     expected = [
         {'Key': 'synapse:createdOn', 'Value': '2020-06-18T16:34:18.000Z'},


### PR DESCRIPTION
Exclude Synapse user profile data[1] that isn't useful for the service
catalog. Also refactored term "ignore" to "exclude"

[1] https://docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html