### PR TITLE
[SC-248] Exclude synapse userProfile data

### DIFF
--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -7,7 +7,8 @@ import os
 SYNAPSE_TAG_PREFIX = 'synapse'
 SYNAPSE_USER_PROFILE_EXCLUDES = [
   "createdOn", "etag", "summary", "profilePicureFileHandleId", "url",
-  "notificationSettings", "preferences"
+  "notificationSettings", "preferences", "position", "location",
+  "email", "emails", "openIds", "industry"
 ]
 
 log = logging.getLogger(__name__)

--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -5,10 +5,8 @@ import boto3
 import os
 
 SYNAPSE_TAG_PREFIX = 'synapse'
-SYNAPSE_USER_PROFILE_EXCLUDES = [
-  "createdOn", "etag", "summary", "profilePicureFileHandleId", "url",
-  "notificationSettings", "preferences", "position", "location",
-  "email", "emails", "openIds", "industry"
+SYNAPSE_USER_PROFILE_INCLUDES = [
+  "ownerId", "firstName", "lastName", "userName", "company", "teamName",
 ]
 
 log = logging.getLogger(__name__)
@@ -86,16 +84,16 @@ def get_synapse_user_team_id(synapse_id, team_ids):
 
   return None
 
-def get_synapse_user_profile_tags(user_profile, excludes=SYNAPSE_USER_PROFILE_EXCLUDES):
+def get_synapse_user_profile_tags(user_profile, includes=SYNAPSE_USER_PROFILE_INCLUDES):
   '''Derive synapse tags from synapse user profile data
   :param user_profile: the synapse user profile info
-  :param excludes: the list of Synapse userProfile data to exclude from tagging
-         Note - no email tags are returned if userName is excluded
+  :param includes: list of Synapse userProfile data to create tags
+         Note - no email tags are returned if userName is not in the list
   :return a list containing a dictionary of tags
   '''
   tags = []
   for key, value in user_profile.items():
-    if key in excludes:
+    if key not in includes:
       continue
 
     # derive synapse email tag based on userName

--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -3,6 +3,7 @@ import logging
 import synapseclient
 import boto3
 import os
+import re
 
 SYNAPSE_TAG_PREFIX = 'synapse'
 SYNAPSE_USER_PROFILE_INCLUDES = [
@@ -90,11 +91,19 @@ def get_synapse_user_profile_tags(user_profile, includes=SYNAPSE_USER_PROFILE_IN
   :param includes: list of Synapse userProfile data to create tags
          Note - no email tags are returned if userName is not in the list
   :return a list containing a dictionary of tags
+         Note - AWS tag restrictions only allow a subset of characters for tag values.
+         The returned list will contain sanitized tag values.
+         https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
   '''
+  VALID_TAG_CHARS = r'[^a-zA-Z0-9.+=_:@/\-]'
+
   tags = []
   for key, value in user_profile.items():
     if key not in includes:
       continue
+
+    # replace invalid characters with a space
+    value = re.sub(VALID_TAG_CHARS, ' ', value)
 
     # derive synapse email tag based on userName
     if key == "userName":

--- a/tests/unit/utils/test_get_synapse_user_profile_tags.py
+++ b/tests/unit/utils/test_get_synapse_user_profile_tags.py
@@ -9,11 +9,18 @@ TEST_USER_PROFILE = {
   "ownerId": "1111111",
   "userName": "jsmith",
   "company": "Sage Bionetworks",
+  "summary": "I'm a sager",
+  "position": "dev guy",
+  "location": "Seattle, WA",
+  "industry": "Life Sciences Research",
+  "profilePicureFileHandleId": "222222",
+  "url": "https://www.linkedin.com/company/sage-bionetworks/",
+  "teamName": "Sage Team"
 }
 
 class TestGetSynapseUserProfileTags(unittest.TestCase):
 
-  def test_happy_default_exclude(self):
+  def test_happy_default_include(self):
     result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE)
     expected = [
         {'Key': 'synapse:firstName', 'Value': 'Joe'},
@@ -23,12 +30,13 @@ class TestGetSynapseUserProfileTags(unittest.TestCase):
         {'Key': 'OwnerEmail', 'Value': 'jsmith@synapse.org'},
         {'Key': 'synapse:userName', 'Value': 'jsmith'},
         {'Key': 'synapse:company', 'Value': 'Sage Bionetworks'},
+        {'Key': 'synapse:teamName', 'Value': 'Sage Team'}
     ]
     self.assertListEqual(result, expected)
 
-  def test_happy_mulitple_excludes(self):
+  def test_happy_mulitple_includes(self):
     result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE,
-                                               ["createdOn","company","firstName","lastName"])
+                                               ["ownerId","userName"])
     expected = [
         {'Key': 'synapse:ownerId', 'Value': '1111111'},
         {'Key': 'synapse:email', 'Value': 'jsmith@synapse.org'},
@@ -37,13 +45,9 @@ class TestGetSynapseUserProfileTags(unittest.TestCase):
     ]
     self.assertListEqual(result, expected)
 
-  def test_happy_excludes_user_name(self):
-    result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE, ["userName"])
+  def test_happy_not_include_user_name(self):
+    result = utils.get_synapse_user_profile_tags(TEST_USER_PROFILE, ["ownerId"])
     expected = [
-        {'Key': 'synapse:createdOn', 'Value': '2020-06-18T16:34:18.000Z'},
-        {'Key': 'synapse:firstName', 'Value': 'Joe'},
-        {'Key': 'synapse:lastName', 'Value': 'Smith'},
-        {'Key': 'synapse:ownerId', 'Value': '1111111'},
-        {'Key': 'synapse:company', 'Value': 'Sage Bionetworks'},
+        {'Key': 'synapse:ownerId', 'Value': '1111111'}
     ]
     self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_synapse_user_profile_tags.py
+++ b/tests/unit/utils/test_get_synapse_user_profile_tags.py
@@ -51,3 +51,26 @@ class TestGetSynapseUserProfileTags(unittest.TestCase):
         {'Key': 'synapse:ownerId', 'Value': '1111111'}
     ]
     self.assertListEqual(result, expected)
+
+  def test_sanitiz_tag_values(self):
+    INVALID_CHAR_USER_PROFILE = {
+      "firstName": "Joe (Barry)",
+      "lastName": "Smith",
+      "ownerId": "1111111",
+      "userName": "jsmith",
+      "company": "Sage-Bionetworks in Seattle, WA",
+      "teamName": "CompOnc;Tesla;SysBio"
+    }
+
+    result = utils.get_synapse_user_profile_tags(INVALID_CHAR_USER_PROFILE)
+    expected = [
+        {'Key': 'synapse:firstName', 'Value': 'Joe  Barry '},
+        {'Key': 'synapse:lastName', 'Value': 'Smith'},
+        {'Key': 'synapse:ownerId', 'Value': '1111111'},
+        {'Key': 'synapse:email', 'Value': 'jsmith@synapse.org'},
+        {'Key': 'OwnerEmail', 'Value': 'jsmith@synapse.org'},
+        {'Key': 'synapse:userName', 'Value': 'jsmith'},
+        {'Key': 'synapse:company', 'Value': 'Sage-Bionetworks in Seattle  WA'},
+        {'Key': 'synapse:teamName', 'Value': 'CompOnc Tesla SysBio'}
+    ]
+    self.assertListEqual(result, expected)


### PR DESCRIPTION
S3 buckets do not allow tag values with certain characters, like a
comma (i.e. Seattle, WA).  This change excludes additional userProfile data[1]
that may contain restricted characters.

The only doc i've run across that touches on character restrictions for tag
values is in the EC2 docs[2]

"Although EC2 allows for any character in its tags, other services are more
restrictive. The allowed characters across services are: letters, numbers,
and spaces representable in UTF-8, and the following characters: + - = . _ : / @."

So it looks like it's not consistent across services. Commas are allowed for
EC2s tags but not for S3 tags.

[1] http://rest-docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html
[2] https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions