### PR TITLE
[SC-255] apply Marketplace tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ dmypy.json
 
 # temp
 temp/
+
+# MAC
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Sage Service Catalog.
 
 ## Inventory of source code and supporting files:
 
-- set_bucket_tags - Function to set tags on S3 buckets.
-- set_instance_tags - Function to set tags on EC2 instances.
+- set_tags - Function to set tags on resources.
 - events - Invocation events that you can use to invoke the function.
 - tests - Unit tests for the application code.
 - template.yaml - A template that defines the application's AWS resources.
@@ -29,6 +28,17 @@ AWS will apply the following tags when resources are provisioned with the Servic
 
 This custom resource uses these tags to retrieve more information and applies
 them as additional tags on the provisioned resource.
+
+### Supported Tags
+
+#### All Resources
+* Synapse tags - Retrieve the [Synapse userProfile](https://docs.synapse.org/rest/org/sagebionetworks/repo/model/UserProfile.html)
+info and apply a subset of that data as tags to resources.
+* Marketplace SC product tags - Get Marketplace SC product code and customer ID from subscriber Dynamo DB and
+apply them as tags.
+
+#### EC2 Only
+* AccessApprovedCaller tag - Generate the info to allow role access to an instance and apply it as a tag on the resource.
 
 ### Parameters
 

--- a/set_tags/set_bucket_tags.py
+++ b/set_tags/set_bucket_tags.py
@@ -56,9 +56,10 @@ def create_or_update(event, context):
   bucket_tags = get_bucket_tags(bucket_name)
   synapse_owner_id = utils.get_synapse_owner_id(bucket_tags)
   synapse_tags = utils.get_synapse_tags(synapse_owner_id)
+  marketplace_tags = utils.get_marketplace_tags(synapse_owner_id)
   # put_bucket_tagging is a replace operation.  need to give it all
   # tags otherwise it will remove existing tags not in the list
-  all_tags = list(bucket_tags + synapse_tags)
+  all_tags = list(bucket_tags + synapse_tags + marketplace_tags)
   log.debug(f'Apply tags: {all_tags} to bucket {bucket_name}')
   apply_tags(bucket_name, all_tags)
 

--- a/set_tags/set_instance_tags.py
+++ b/set_tags/set_instance_tags.py
@@ -83,6 +83,8 @@ def create_or_update(event, context):
   extra_tags.append(provisioned_product_name_tag)
   access_approved_role_tag = utils.get_access_approved_role_tag(instance_tags)
   extra_tags.append(access_approved_role_tag)
+  marketplace_tags = utils.get_marketplace_tags(synapse_owner_id)
+  extra_tags.append(marketplace_tags)
   all_tags = list(synapse_tags + extra_tags)
 
   volume_ids = get_volume_ids(instance_id)

--- a/set_tags/set_instance_tags.py
+++ b/set_tags/set_instance_tags.py
@@ -84,8 +84,7 @@ def create_or_update(event, context):
   access_approved_role_tag = utils.get_access_approved_role_tag(instance_tags)
   extra_tags.append(access_approved_role_tag)
   marketplace_tags = utils.get_marketplace_tags(synapse_owner_id)
-  extra_tags.append(marketplace_tags)
-  all_tags = list(synapse_tags + extra_tags)
+  all_tags = list(synapse_tags + extra_tags + marketplace_tags)
 
   volume_ids = get_volume_ids(instance_id)
   log.debug(f'Apply tags: {all_tags} to volume {volume_ids}')

--- a/template.yaml
+++ b/template.yaml
@@ -40,6 +40,8 @@ Resources:
       Environment:
         Variables:
           TEAM_TO_ROLE_ARN_MAP_PARAM_NAME: !Ref TeamToRoleArnMapParamName
+          MARKETPLACE_ID_DYNAMO_TABLE_NAME: !ImportValue
+            'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTable'
 
   SetBucketTagsFunctionRole:
     Type: AWS::IAM::Role
@@ -57,6 +59,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - !Ref BucketTagPolicy
         - !Ref SsmManagedPolicy
+        - !Ref DynamoDbManagedPolicy
 
   BucketTagPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -80,6 +83,8 @@ Resources:
       Environment:
         Variables:
           TEAM_TO_ROLE_ARN_MAP_PARAM_NAME: !Ref TeamToRoleArnMapParamName
+          MARKETPLACE_ID_DYNAMO_TABLE_NAME: !ImportValue
+            'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTable'
 
   SetInstanceTagsFunctionRole:
     Type: AWS::IAM::Role
@@ -97,6 +102,7 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
         - !Ref InstanceTagPolicy
         - !Ref SsmManagedPolicy
+        - !Ref DynamoDbManagedPolicy
 
   InstanceTagPolicy:
     Type: AWS::IAM::ManagedPolicy
@@ -125,6 +131,21 @@ Resources:
               - 'ssm:*'
             Effect: Allow
             Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${TeamToRoleArnMapParamName}'
+
+  DynamoDbManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: DynanoDbAccess
+            Action:
+              - 'dynamodb:*Get*'
+              - 'dynamodb:*List*'
+            Effect: Allow
+            Resource: !ImportValue
+              'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTableArn'
+
 Outputs:
   SetBucketTagsFunctionName:
     Value: !Ref SetBucketTagsFunction

--- a/template.yaml
+++ b/template.yaml
@@ -138,7 +138,7 @@ Resources:
       PolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Sid: DynanoDbAccess
+          - Sid: DynamoDbAccess
             Action:
               - 'dynamodb:*Get*'
               - 'dynamodb:*List*'

--- a/tests/unit/utils/test_get_marketplace_customer_id.py
+++ b/tests/unit/utils/test_get_marketplace_customer_id.py
@@ -1,0 +1,40 @@
+import unittest
+
+from unittest.mock import MagicMock, patch
+from botocore.stub import Stubber
+from set_tags import utils
+
+
+class TestGetInstanceTags(unittest.TestCase):
+
+  def test_registered_customer(self):
+    ddb = utils.get_dynamo_client()
+    with Stubber(ddb) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_val:
+      env_var_val.return_value = "SomeTable"
+      response = {
+          "Item": {
+              "marketplaceCustomerId": {
+                  "S": "mkt-cust-1234"
+              }
+          }
+      }
+      stubber.add_response('get_item', response)
+      utils.get_dynamo_client = MagicMock(return_value=ddb)
+      synapse_id = "1234567"
+      result = utils.get_marketplace_customer_id(synapse_id)
+      self.assertEqual("mkt-cust-1234", result)
+
+  def test_no_registered_customer(self):
+    ddb = utils.get_dynamo_client()
+    with Stubber(ddb) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_val:
+      env_var_val.return_value = "SomeTable"
+      response = {
+          "Item": {}
+      }
+      stubber.add_response('get_item', response)
+      utils.get_dynamo_client = MagicMock(return_value=ddb)
+      synapse_id = "1234567"
+      result = utils.get_marketplace_customer_id(synapse_id)
+      self.assertEqual(None, result)

--- a/tests/unit/utils/test_get_marketplace_customer_id.py
+++ b/tests/unit/utils/test_get_marketplace_customer_id.py
@@ -14,7 +14,7 @@ class TestGetMarketplaceCustomerId(unittest.TestCase):
       env_var_val.return_value = "SomeTable"
       response = {
           "Item": {
-              "marketplaceCustomerId": {
+              "MarketplaceCustomerId": {
                   "S": "mkt-cust-1234"
               }
           }
@@ -30,9 +30,7 @@ class TestGetMarketplaceCustomerId(unittest.TestCase):
     with Stubber(ddb) as stubber, \
       patch('set_tags.utils.get_env_var_value') as env_var_val:
       env_var_val.return_value = "SomeTable"
-      response = {
-          "Item": {}
-      }
+      response = {}
       stubber.add_response('get_item', response)
       utils.get_dynamo_client = MagicMock(return_value=ddb)
       synapse_id = "1234567"

--- a/tests/unit/utils/test_get_marketplace_customer_id.py
+++ b/tests/unit/utils/test_get_marketplace_customer_id.py
@@ -5,7 +5,7 @@ from botocore.stub import Stubber
 from set_tags import utils
 
 
-class TestGetInstanceTags(unittest.TestCase):
+class TestGetMarketplaceCustomerId(unittest.TestCase):
 
   def test_registered_customer(self):
     ddb = utils.get_dynamo_client()

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -1,0 +1,22 @@
+import unittest
+import boto3
+
+from unittest.mock import patch
+from set_tags import utils
+from botocore.stub import Stubber
+
+class TestGetMarketplaceTags(unittest.TestCase):
+
+  def test_happy_path(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
+        customer_id_mock.return_value = "mkt-cust-1234"
+        ssm_param_mock.return_value = "mkt-prod-1234"
+        result = utils.get_marketplace_tags(1234567)
+        expected = [
+          {'Key': 'synapse:marketplaceProductCode', 'Value': 'mkt-prod-1234'},
+          {'Key': 'synapse:marketplaceCustomerId', 'Value': 'mkt-cust-1234'}
+        ]
+        self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -7,7 +7,7 @@ from botocore.stub import Stubber
 
 class TestGetMarketplaceTags(unittest.TestCase):
 
-  def test_happy_path(self):
+  def test_has_tags(self):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
@@ -19,4 +19,41 @@ class TestGetMarketplaceTags(unittest.TestCase):
           {'Key': 'synapse:marketplaceProductCode', 'Value': 'mkt-prod-1234'},
           {'Key': 'synapse:marketplaceCustomerId', 'Value': 'mkt-cust-1234'}
         ]
+        self.assertListEqual(result, expected)
+
+  def test_no_product_code_tag(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
+        customer_id_mock.return_value = ""
+        ssm_param_mock.return_value = "mkt-prod-1234"
+        result = utils.get_marketplace_tags(1234567)
+        expected = [
+          {'Key': 'synapse:marketplaceProductCode', 'Value': 'mkt-prod-1234'}
+        ]
+        self.assertListEqual(result, expected)
+
+  def test_no_customer_id_tag(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
+        customer_id_mock.return_value = "mkt-cust-1234"
+        ssm_param_mock.return_value = ""
+        result = utils.get_marketplace_tags(1234567)
+        expected = [
+          {'Key': 'synapse:marketplaceCustomerId', 'Value': 'mkt-cust-1234'}
+        ]
+        self.assertListEqual(result, expected)
+
+  def test_no_tags(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
+        customer_id_mock.return_value = ""
+        ssm_param_mock.return_value = ""
+        result = utils.get_marketplace_tags(1234567)
+        expected = []
         self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -21,7 +21,7 @@ class TestGetMarketplaceTags(unittest.TestCase):
         ]
         self.assertListEqual(result, expected)
 
-  def test_no_product_code_tag(self):
+  def test_no_customer_id_tag(self):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
@@ -34,7 +34,7 @@ class TestGetMarketplaceTags(unittest.TestCase):
         ]
         self.assertListEqual(result, expected)
 
-  def test_no_customer_id_tag(self):
+  def test_no_product_code_tag(self):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -16,8 +16,8 @@ class TestGetMarketplaceTags(unittest.TestCase):
         ssm_param_mock.return_value = "mkt-prod-1234"
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'synapse:marketplaceProductCode', 'Value': 'mkt-prod-1234'},
-          {'Key': 'synapse:marketplaceCustomerId', 'Value': 'mkt-cust-1234'}
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'},
+          {'Key': 'marketplace:customerId', 'Value': 'mkt-cust-1234'}
         ]
         self.assertListEqual(result, expected)
 
@@ -30,7 +30,7 @@ class TestGetMarketplaceTags(unittest.TestCase):
         ssm_param_mock.return_value = "mkt-prod-1234"
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'synapse:marketplaceProductCode', 'Value': 'mkt-prod-1234'}
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'}
         ]
         self.assertListEqual(result, expected)
 
@@ -43,7 +43,7 @@ class TestGetMarketplaceTags(unittest.TestCase):
         ssm_param_mock.return_value = ""
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'synapse:marketplaceCustomerId', 'Value': 'mkt-cust-1234'}
+          {'Key': 'marketplace:customerId', 'Value': 'mkt-cust-1234'}
         ]
         self.assertListEqual(result, expected)
 


### PR DESCRIPTION
Make the tagger apply AWS Marketplace SC subscriber info as tags
on resources.  The idea is to have these tags available for a
another lambda to send metering information of the resources
to the marketplace.

depends on Sage-Bionetworks/scipool-infra#214  Sage-Bionetworks/scipool-infra#217