### PR TITLE
Fix get marketplace product code from SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,13 @@ apply them as tags.
 
 ### Parameters
 
-To determine a team tag this custom resource assumes that there is a `/service-catalog/TeamToRoleArnMap`
-parameter in the AWS SSM parameter store.  The specification for that parameter is defined by the
-[synapse login app](https://github.com/Sage-Bionetworks/synapse-login-scipool#team-to-role-map).
+This custom resource assumes the existence of the following SSM parameters:
+
+* `/service-catalog/TeamToRoleArnMap` - to determine the synapse team ID tag
+* `/service-catalog/MarketplaceProductCodeSC` - to determine the service catalog AWS Marketplace product code
+
+The specification for these parameters are defined by the
+[synapse login app](https://github.com/Sage-Bionetworks/synapse-login-scipool#configurations).
 
 ## Use in a Cloudformation Template
 
@@ -165,6 +169,7 @@ template_path: "remote/cfn-cr-synapse-tagger.yaml"
 stack_name: "cfn-cr-synapse-tagger"
 parameters:
   TeamToRoleArnMapParamName: "/service-catalog/TeamToRoleArnMap"
+  MarketplaceProductCodeSCParamName: "/service-catalog/MarketplaceProductCodeSC"
 hooks:
   before_launch:
     - !cmd "curl https://s3.amazonaws.com/essentials-awss3lambdaartifactsbucket-x29ftznj6pqw/it-lambda-set-bucket-tags/master/cfn-cr-synapse-tagger.yaml --create-dirs -o templates/remote/cfn-cr-synapse-tagger.yaml"

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ apply them as tags.
 
 This custom resource assumes the existence of the following SSM parameters:
 
-* `/service-catalog/TeamToRoleArnMap` - to determine the synapse team ID tag
-* `/service-catalog/MarketplaceProductCodeSC` - to determine the service catalog AWS Marketplace product code
+* `/service-catalog/TeamToRoleArnMap` - used to determine and apply the Synapse team tag
+* `/service-catalog/MarketplaceProductCodeSC` - used to apply the service catalog AWS Marketplace product code tag
 
 The specification for these parameters are defined by the
 [synapse login app](https://github.com/Sage-Bionetworks/synapse-login-scipool#configurations).

--- a/README.md
+++ b/README.md
@@ -131,11 +131,11 @@ which requires permissions to upload to Sage
 `essentials-awss3lambdaartifactsbucket-x29ftznj6pqw` buckets.
 
 ```shell script
-sam package --template-file template.yaml \
+sam package --template-file .aws-sam/build/template.yaml \
   --s3-bucket essentials-awss3lambdaartifactsbucket-x29ftznj6pqw \
   --output-template-file .aws-sam/build/cfn-cr-synapse-tagger.yaml
 
-aws s3 cp .aws-sam/build/cfn-cr-synapse-tagger.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/cfn-cr-synapse-tagger/master
+aws s3 cp .aws-sam/build/cfn-cr-synapse-tagger.yaml s3://bootstrap-awss3cloudformationbucket-19qromfd235z9/cfn-cr-synapse-tagger/master/
 ```
 
 ## Publish Lambda

--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -69,7 +69,7 @@ def get_synapse_team_ids():
   TeamToRoleArnMap = get_env_var_value('TEAM_TO_ROLE_ARN_MAP_PARAM_NAME')
   ssm_param = get_ssm_parameter(TeamToRoleArnMap)
   team_to_role_arn_map = json.loads(ssm_param["Parameter"]["Value"])
-  log.debug(f'{TeamToRoleArnMap} value: {team_to_role_arn_map}')
+  log.debug(f'ssm param: {TeamToRoleArnMap} = {team_to_role_arn_map}')
   team_ids = []
   for item in team_to_role_arn_map:
     team_ids.append(item["teamId"])
@@ -234,8 +234,9 @@ def get_marketplace_tags(synapse_id):
   tags = []
 
   ssm_param_marketplace_product_code = get_env_var_value('MARKETPLACE_PRODUCT_CODE_SC_PARAM_NAME')
-  marketplace_product_code_sc = get_ssm_parameter(ssm_param_marketplace_product_code)
-  log.debug(f'{ssm_param_marketplace_product_code} value: {marketplace_product_code_sc}')
+  ssm_param = get_ssm_parameter(ssm_param_marketplace_product_code)
+  marketplace_product_code_sc = ssm_param["Parameter"]["Value"]
+  log.debug(f'ssm param: {ssm_param_marketplace_product_code} = {marketplace_product_code_sc}')
   if marketplace_product_code_sc:
     tags.append({'Key': f'{MARKETPLACE_TAG_PREFIX}:productCode', 'Value': marketplace_product_code_sc})
 

--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -69,7 +69,7 @@ def get_synapse_team_ids():
   TeamToRoleArnMap = get_env_var_value('TEAM_TO_ROLE_ARN_MAP_PARAM_NAME')
   ssm_param = get_ssm_parameter(TeamToRoleArnMap)
   team_to_role_arn_map = json.loads(ssm_param["Parameter"]["Value"])
-  log.debug(f'/service-catalog/TeamToRoleArnMap value: {team_to_role_arn_map}')
+  log.debug(f'{TeamToRoleArnMap} value: {team_to_role_arn_map}')
   team_ids = []
   for item in team_to_role_arn_map:
     team_ids.append(item["teamId"])
@@ -233,7 +233,9 @@ def get_marketplace_tags(synapse_id):
   '''
   tags = []
 
-  marketplace_product_code_sc = get_ssm_parameter("MarketplaceProductCodeSC")
+  ssm_param_marketplace_product_code = get_env_var_value('MARKETPLACE_PRODUCT_CODE_SC_PARAM_NAME')
+  marketplace_product_code_sc = get_ssm_parameter(ssm_param_marketplace_product_code)
+  log.debug(f'{ssm_param_marketplace_product_code} value: {marketplace_product_code_sc}')
   if marketplace_product_code_sc:
     tags.append({'Key': f'{MARKETPLACE_TAG_PREFIX}:productCode', 'Value': marketplace_product_code_sc})
 

--- a/template.yaml
+++ b/template.yaml
@@ -23,6 +23,10 @@ Parameters:
     Description: 'The TeamToRoleArnMap parameter name in the SSM parameter store'
     Type: String
     Default: '/service-catalog/TeamToRoleArnMap'
+  MarketplaceProductCodeSCParamName:
+    Description: 'The MarketplaceProductCodeSC parameter name in the SSM parameter store'
+    Type: String
+    Default: '/service-catalog/MarketplaceProductCodeSC'
 
 Globals:
   Function:
@@ -40,6 +44,7 @@ Resources:
       Environment:
         Variables:
           TEAM_TO_ROLE_ARN_MAP_PARAM_NAME: !Ref TeamToRoleArnMapParamName
+          MARKETPLACE_PRODUCT_CODE_SC_PARAM_NAME: !Ref MarketplaceProductCodeSCParamName
           MARKETPLACE_ID_DYNAMO_TABLE_NAME: !ImportValue
             'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTable'
 
@@ -83,6 +88,7 @@ Resources:
       Environment:
         Variables:
           TEAM_TO_ROLE_ARN_MAP_PARAM_NAME: !Ref TeamToRoleArnMapParamName
+          MARKETPLACE_PRODUCT_CODE_SC_PARAM_NAME: !Ref MarketplaceProductCodeSCParamName
           MARKETPLACE_ID_DYNAMO_TABLE_NAME: !ImportValue
             'Fn::Sub': '${AWS::Region}-marketplace-dynamo-MarketplaceDynamoDBTable'
 
@@ -130,7 +136,9 @@ Resources:
             Action:
               - 'ssm:*'
             Effect: Allow
-            Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${TeamToRoleArnMapParamName}'
+            Resource:
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${TeamToRoleArnMapParamName}'
+              - !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MarketplaceProductCodeSCParamName}'
 
   DynamoDbManagedPolicy:
     Type: AWS::IAM::ManagedPolicy

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -7,16 +7,28 @@ from botocore.stub import Stubber
 
 class TestGetMarketplaceTags(unittest.TestCase):
 
+  MOCK_MARKETPLACE_PRODUCTT_CODE_SC = {
+    "Parameter": {
+      "Name": "/service-catalog/MarketplaceProductCodeSC",
+      "Type": "String",
+      "Value": "mkt-cust-1234",
+      "Version": 1,
+      "LastModifiedDate": "today",
+      "ARN": "arn:aws:ssm:us-east-1:1111111111:parameter/service-catalog/MarketplaceProductCodeSC",
+      "DataType": "text"
+    }
+  }
+
   def test_has_tags(self):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = "mkt-cust-1234"
-        ssm_param_mock.return_value = "mkt-prod-1234"
+        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCTT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'},
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-cust-1234'},
           {'Key': 'marketplace:customerId', 'Value': 'mkt-cust-1234'}
         ]
         self.assertListEqual(result, expected)
@@ -27,10 +39,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = ""
-        ssm_param_mock.return_value = "mkt-prod-1234"
+        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCTT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'}
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-cust-1234'}
         ]
         self.assertListEqual(result, expected)
 
@@ -40,7 +52,17 @@ class TestGetMarketplaceTags(unittest.TestCase):
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = "mkt-cust-1234"
-        ssm_param_mock.return_value = ""
+        ssm_param_mock.return_value = {
+          "Parameter": {
+            "Name": "/service-catalog/MarketplaceProductCodeSC",
+            "Type": "String",
+            "Value": "",
+            "Version": 1,
+            "LastModifiedDate": "today",
+            "ARN": "arn:aws:ssm:us-east-1:1111111111:parameter/service-catalog/MarketplaceProductCodeSC",
+            "DataType": "text"
+          }
+        }
         result = utils.get_marketplace_tags(1234567)
         expected = [
           {'Key': 'marketplace:customerId', 'Value': 'mkt-cust-1234'}
@@ -53,7 +75,17 @@ class TestGetMarketplaceTags(unittest.TestCase):
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = ""
-        ssm_param_mock.return_value = ""
+        ssm_param_mock.return_value = {
+          "Parameter": {
+            "Name": "/service-catalog/MarketplaceProductCodeSC",
+            "Type": "String",
+            "Value": "",
+            "Version": 1,
+            "LastModifiedDate": "today",
+            "ARN": "arn:aws:ssm:us-east-1:1111111111:parameter/service-catalog/MarketplaceProductCodeSC",
+            "DataType": "text"
+          }
+        }
         result = utils.get_marketplace_tags(1234567)
         expected = []
         self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -7,11 +7,11 @@ from botocore.stub import Stubber
 
 class TestGetMarketplaceTags(unittest.TestCase):
 
-  MOCK_MARKETPLACE_PRODUCTT_CODE_SC = {
+  MOCK_MARKETPLACE_PRODUCT_CODE_SC = {
     "Parameter": {
       "Name": "/service-catalog/MarketplaceProductCodeSC",
       "Type": "String",
-      "Value": "mkt-cust-1234",
+      "Value": "mkt-prod-1234",
       "Version": 1,
       "LastModifiedDate": "today",
       "ARN": "arn:aws:ssm:us-east-1:1111111111:parameter/service-catalog/MarketplaceProductCodeSC",
@@ -25,10 +25,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = "mkt-cust-1234"
-        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCTT_CODE_SC
+        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'marketplace:productCode', 'Value': 'mkt-cust-1234'},
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'},
           {'Key': 'marketplace:customerId', 'Value': 'mkt-cust-1234'}
         ]
         self.assertListEqual(result, expected)
@@ -39,10 +39,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = ""
-        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCTT_CODE_SC
+        ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
-          {'Key': 'marketplace:productCode', 'Value': 'mkt-cust-1234'}
+          {'Key': 'marketplace:productCode', 'Value': 'mkt-prod-1234'}
         ]
         self.assertListEqual(result, expected)
 


### PR DESCRIPTION
The lambda failed to get the SC AWS marketplace product code from the SSM.
We need to pass in the parameter name and look it up in the SSM with the
name.  Also we need to give the lambda access to the SSM parameter.