### PR TITLE
Skip applying tags if ENV VAR is not defined.

### DIFF
--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -39,7 +39,7 @@ def get_env_var_value(env_var):
   '''
   value = os.getenv(env_var)
   if not value:
-    log.warning(f'cannot get envirooment variable: {env_var}')
+    log.warning(f'cannot get environment variable: {env_var}')
 
   return value
 

--- a/tests/unit/utils/test_get_marketplace_customer_id.py
+++ b/tests/unit/utils/test_get_marketplace_customer_id.py
@@ -36,3 +36,13 @@ class TestGetMarketplaceCustomerId(unittest.TestCase):
       synapse_id = "1234567"
       result = utils.get_marketplace_customer_id(synapse_id)
       self.assertEqual(None, result)
+
+  def test_no_env_var_marketplace_id_dynamo_table_name(self):
+    ddb = utils.get_dynamo_client()
+    with Stubber(ddb) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock:
+        env_var_mock.return_value = None
+        synapse_id = "1234567"
+        result = utils.get_marketplace_customer_id(synapse_id)
+        expected = None
+        self.assertEqual(result, expected)

--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -23,8 +23,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = "mkt-cust-1234"
+        env_var_mock.return_value = "some-value"
         ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
@@ -37,8 +39,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = ""
+        env_var_mock.return_value = "some-value"
         ssm_param_mock.return_value = self.MOCK_MARKETPLACE_PRODUCT_CODE_SC
         result = utils.get_marketplace_tags(1234567)
         expected = [
@@ -50,8 +54,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = "mkt-cust-1234"
+        env_var_mock.return_value = "some-value"
         ssm_param_mock.return_value = {
           "Parameter": {
             "Name": "/service-catalog/MarketplaceProductCodeSC",
@@ -73,8 +79,10 @@ class TestGetMarketplaceTags(unittest.TestCase):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
       patch('set_tags.utils.get_marketplace_customer_id') as customer_id_mock, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock, \
       patch('set_tags.utils.get_ssm_parameter') as ssm_param_mock:
         customer_id_mock.return_value = ""
+        env_var_mock.return_value = "some-value"
         ssm_param_mock.return_value = {
           "Parameter": {
             "Name": "/service-catalog/MarketplaceProductCodeSC",
@@ -86,6 +94,15 @@ class TestGetMarketplaceTags(unittest.TestCase):
             "DataType": "text"
           }
         }
+        result = utils.get_marketplace_tags(1234567)
+        expected = []
+        self.assertListEqual(result, expected)
+
+  def test_no_env_var_marketplace_product_code_sc_param_name(self):
+    ddb = utils.get_dynamo_client()
+    with Stubber(ddb) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock:
+        env_var_mock.return_value = None
         result = utils.get_marketplace_tags(1234567)
         expected = []
         self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_synapse_team_ids.py
+++ b/tests/unit/utils/test_get_synapse_team_ids.py
@@ -23,8 +23,19 @@ class TestGetSynapseTeamIds(unittest.TestCase):
   def test_happy_path(self):
     ssm = boto3.client('ssm')
     with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock, \
       patch('set_tags.utils.get_ssm_parameter') as param_mock:
+        env_var_mock.return_value = "some-value"
         param_mock.return_value = MOCK_GET_PARAMETER_RESPONSE
         result = utils.get_synapse_team_ids()
         expected = ["1111111","2222222"]
+        self.assertListEqual(result, expected)
+
+  def test_no_env_var_team_to_role_arn_map_param_name(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_env_var_value') as env_var_mock:
+        env_var_mock.return_value = None
+        result = utils.get_synapse_team_ids()
+        expected = []
         self.assertListEqual(result, expected)


### PR DESCRIPTION
We had to revert PR https://github.com/Sage-Bionetworks/scipool-infra/pull/225
because this lambda would fail to run if dependent ENV VARS are not setup.
For example the `MarketplaceProductCodeSC` has not been setup in production
environments because we have not completed development and testing of
the aws marketplace integration in the develop environment yet.

This change makes it so that the labmda doesn't error when the ENV VARs
are not setup.  Instead the lambda will just skip applying tags if the
required ENV VAR is not defined.  This will allow us to deploy the
lambda in all environments.