### PR TITLE
Skip applying tags if SSM parameter is not found

### DIFF
--- a/tests/unit/utils/test_get_marketplace_tags.py
+++ b/tests/unit/utils/test_get_marketplace_tags.py
@@ -106,3 +106,12 @@ class TestGetMarketplaceTags(unittest.TestCase):
         result = utils.get_marketplace_tags(1234567)
         expected = []
         self.assertListEqual(result, expected)
+
+  def test_no_ssm_param_marketplace_product_code_sc(self):
+    ddb = utils.get_dynamo_client()
+    with Stubber(ddb) as stubber, \
+      patch('set_tags.utils.get_ssm_parameter') as get_ssm_param_mock:
+        get_ssm_param_mock.return_value = None
+        result = utils.get_marketplace_tags(1234567)
+        expected = []
+        self.assertListEqual(result, expected)

--- a/tests/unit/utils/test_get_synapse_team_ids.py
+++ b/tests/unit/utils/test_get_synapse_team_ids.py
@@ -39,3 +39,12 @@ class TestGetSynapseTeamIds(unittest.TestCase):
         result = utils.get_synapse_team_ids()
         expected = []
         self.assertListEqual(result, expected)
+
+  def test_no_ssm_param_role_arn_map(self):
+    ssm = boto3.client('ssm')
+    with Stubber(ssm) as stubber, \
+      patch('set_tags.utils.get_ssm_parameter') as get_ssm_param_mock:
+        get_ssm_param_mock.return_value = None
+        result = utils.get_synapse_team_ids()
+        expected = []
+        self.assertListEqual(result, expected)


### PR DESCRIPTION
In commit 92bbf1c02 we checked for the existence of parameter names
in ENV VARs however we forgot to also check that we can get that
parameter from the SSM.  This adds functionality to make sure we
can get the parameter from the SSM before applying tags.