### PR TITLE
[SC-379] Refactor set batch tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Create a custom resource in your cloudformation template. Here's an example:
     Properties:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBatchTagsFunctionArn'
-      StackId: !Ref AWS::StackId
       BatchResources:
         JobDefinitionArn: !Ref JobDefinition
         JobQueueArn: !Ref JobQueue

--- a/README.md
+++ b/README.md
@@ -92,10 +92,12 @@ Create a custom resource in your cloudformation template. Here's an example:
     Properties:
       ServiceToken: !ImportValue
         'Fn::Sub': '${AWS::Region}-cfn-cr-synapse-tagger-SetBatchTagsFunctionArn'
-      JobDefinitionArn: !Ref JobDefinition
-      JobQueueArn: !Ref JobQueue
-      ComputeEnvironmentArn: !Ref ComputeEnvironment
-      SchedulingPolicyArn: !Ref SchedulingPolicy
+      StackId: !Ref AWS::StackId
+      BatchResources:
+        JobDefinitionArn: !Ref JobDefinition
+        JobQueueArn: !Ref JobQueue
+        ComputeEnvironmentArn: !Ref ComputeEnvironment
+        SchedulingPolicyArn: !Ref SchedulingPolicy
 ```
 
 ## Development

--- a/set_tags/set_batch_tags.py
+++ b/set_tags/set_batch_tags.py
@@ -54,16 +54,20 @@ def create_or_update(event, context):
   stack_tags = utils.get_cfn_stack_tags(stack_id)
   synapse_owner_id = utils.get_synapse_owner_id(stack_tags)
 
-  synapse_tags = utils.get_synapse_tags(synapse_owner_id)
+  # get synapse tags and format it into dict key/pair
+  synapse_tags_kv = utils.get_synapse_tags(synapse_owner_id)
+  synapse_tags_kp = utils.format_tags_kv_kp(synapse_tags_kv)
+
+  # get passed in batch resource ARNs
   batch_resources = utils.get_property_value(event, "BatchResources")
   if not batch_resources:
     raise Exception(f'No batch resources passed in, received: {batch_resources}')
 
+  # apply tags to each batch resource
   for key, value in batch_resources.items():
     resource_arn = value
     log.debug(f'Apply tags: {synapse_tags} to resource {resource_arn}')
-    batch_formatted_tags = utils.format_tags_kv_kp(synapse_tags)
-    apply_tags(resource_arn, batch_formatted_tags)
+    apply_tags(resource_arn, synapse_tags_kp)
 
 @helper.delete
 def delete(event, context):

--- a/set_tags/set_batch_tags.py
+++ b/set_tags/set_batch_tags.py
@@ -11,16 +11,11 @@ helper = CfnResource(
   json_logging=False, log_level='DEBUG', boto_level='CRITICAL')
 
 
-def get_resource_arn(event, parameter):
-  '''Get the resource ARN from event params sent to lambda'''
-  resource_properties = event.get('ResourceProperties')
-  resource_arn = resource_properties.get(parameter)
-  if not resource_arn:
-    raise ValueError(f'Missing template parameter: {parameter}')
-  return resource_arn
+def get_batch_tags(resource_arn):
+  '''Look up the batch tags
 
-def get_resource_tags(resource_arn):
-  '''Look up the resource tags'''
+  resource_arn: the ARN of the AWS resource
+  '''
   client = utils.get_batch_client()
   response = client.list_tags_for_resource(
     resourceArn=resource_arn
@@ -32,15 +27,17 @@ def get_resource_tags(resource_arn):
 
   return tags
 
-def apply_tags(name, resource_arn, tags):
-  '''Apply tags to a batch resource'''
+def apply_tags(resource_arn, tags):
+  '''Apply tags to a batch resource
+
+  resource_arn: the ARN of the AWS resource
+  tags: A dictionary of key pairs
+      i.e. tags:{'string':'string'}
+  '''
   client = utils.get_batch_client()
-  batch_formatted_tags = {}  # batch accepts tags formatted as tags={'string': 'string'}
-  for tag in tags:
-    batch_formatted_tags[tag['Key']] = tag['Value']
   response = client.tag_resource(
     resourceArn=resource_arn,
-    tags=batch_formatted_tags
+    tags=tags
   )
   log.debug(f'Apply tags response: {response}')
 
@@ -50,21 +47,23 @@ def create_or_update(event, context):
   '''Handles customm resource create and update events'''
   log.debug('Received event: ' + json.dumps(event, sort_keys=False))
   log.info('Start Lambda processing')
-  # Batch resources that support tags are compute environments, jobs, job definitions,
-  # job queues, and scheduling policies
-  template_input_parameters = [
-    "JobDefinitionArn",
-    "JobQueueArn",
-    "ComputeEnvironmentArn",
-    "SchedulingPolicyArn"
-  ]
-  for template_input_parameter in template_input_parameters:
-    resource_arn = get_resource_arn(event, template_input_parameter)
-    resource_tags = get_resource_tags(resource_arn)
-    synapse_owner_id = utils.get_synapse_owner_id(resource_tags)
-    synapse_tags = utils.get_synapse_tags(synapse_owner_id)
+
+  # workaround for AWS bug in issue SC-379 (AWS case 9477374541)
+  # get synapse owner id from cloudformation stack
+  stack_id = utils.get_stack_id(event)
+  stack_tags = utils.get_cfn_stack_tags(stack_id)
+  synapse_owner_id = utils.get_synapse_owner_id(stack_tags)
+
+  synapse_tags = utils.get_synapse_tags(synapse_owner_id)
+  batch_resources = utils.get_property_value(event, "BatchResources")
+  if not batch_resources:
+    raise Exception(f'No batch resources passed in, received: {batch_resources}')
+
+  for key, value in batch_resources.items():
+    resource_arn = value
     log.debug(f'Apply tags: {synapse_tags} to resource {resource_arn}')
-    apply_tags(resource_arn, synapse_tags)
+    batch_formatted_tags = utils.format_tags_kv_kp(synapse_tags)
+    apply_tags(resource_arn, batch_formatted_tags)
 
 @helper.delete
 def delete(event, context):

--- a/tests/unit/set_tags/test_get_batch_tags.py
+++ b/tests/unit/set_tags/test_get_batch_tags.py
@@ -1,0 +1,54 @@
+import unittest
+from unittest.mock import MagicMock
+
+import boto3
+import botocore
+from botocore.stub import Stubber
+
+from set_tags import set_batch_tags
+from set_tags import utils
+
+
+class TestGetBatchTags(unittest.TestCase):
+
+  def test_valid_instance(self):
+    batch = utils.get_batch_client()
+    with Stubber(batch) as stubber:
+      tags = {
+        'heresatag': 'heresatagvalue',
+        'theresatag': 'theresatagvalue',
+        'anothertag': 'anothertagvalue'
+      }
+      response = {
+        'tags': tags
+      }
+      stubber.add_response('list_tags_for_resource', response)
+      utils.get_batch_client = MagicMock(return_value=batch)
+      valid_resource_id ='some_reasonable_instance_id'
+      result = set_batch_tags.get_batch_tags(valid_resource_id)
+      self.assertEqual(tags, result)
+
+
+  def test_invalid_instance(self):
+    batch = utils.get_batch_client()
+    with Stubber(batch) as stubber, self.assertRaises(botocore.exceptions.ClientError):
+      stubber.add_client_error(
+        method='list_tags_for_resource',
+        service_error_code='NoSuchResource',
+        service_message='Resource was not found',
+        http_status_code=404)
+      utils.get_batch_client = MagicMock(return_value=batch)
+      invalid_resource_id ='some_unreasonable_instance_id'
+      result = set_batch_tags.get_batch_tags(invalid_resource_id)
+
+
+  def test_no_tags(self):
+    batch = utils.get_batch_client()
+    with Stubber(batch) as stubber, self.assertRaises(Exception):
+      response = {
+        'tags': []
+      }
+      stubber.add_response('list_tags_for_resource', response)
+      utils.get_batch_client = MagicMock(return_value=batch)
+      valid_resource_id ='some_reasonable_instance_id'
+      result = set_instance_tags.get_instance_tags(valid_resource_id)

--- a/tests/unit/set_tags/test_set_batch_apply_tags.py
+++ b/tests/unit/set_tags/test_set_batch_apply_tags.py
@@ -1,0 +1,36 @@
+import unittest
+from unittest.mock import MagicMock
+
+from botocore.stub import Stubber
+
+from set_tags import set_batch_tags
+from set_tags import utils
+
+
+class TestSetBatchTagsHandler(unittest.TestCase):
+
+  STACK_ID = 'arn:aws:cloudformation:us-east-1:1111111111:stack/SC-465877038949-pp-yd5tcochoi32c/932c7240-74bc-11ec-9ed8-0ab60a8ca761'
+  TEST_TAGS = {
+    'foo': 'bar'
+  }
+
+  def test_happy_path(self):
+    batch = utils.get_batch_client()
+    with Stubber(batch) as stubber:
+      stubber.add_response(
+        method='tag_resource',
+        expected_params={
+          'resourceArn': self.STACK_ID,
+          'tags': self.TEST_TAGS
+        },
+        service_response={
+          'ResponseMetadata': {
+            'RequestId': '12345',
+            'HostId': 'etc',
+            'HTTPStatusCode': 204,
+            'HTTPHeaders': {}
+          }})
+      utils.get_batch_client = MagicMock(return_value=batch)
+      result = set_batch_tags.apply_tags(self.STACK_ID, self.TEST_TAGS)
+
+

--- a/tests/unit/set_tags/test_set_batch_apply_tags.py
+++ b/tests/unit/set_tags/test_set_batch_apply_tags.py
@@ -32,5 +32,3 @@ class TestSetBatchTagsHandler(unittest.TestCase):
           }})
       utils.get_batch_client = MagicMock(return_value=batch)
       result = set_batch_tags.apply_tags(self.STACK_ID, self.TEST_TAGS)
-
-

--- a/tests/unit/utils/test_format_tags.py
+++ b/tests/unit/utils/test_format_tags.py
@@ -1,0 +1,25 @@
+import unittest
+
+from set_tags import utils
+
+
+class TestFormatTags(unittest.TestCase):
+
+  def test_format_tags_none(self):
+    tags = []
+    result = utils.format_tags_kv_kp(tags)
+    self.assertEqual(result, {})
+
+  def test_format_tags_multiple(self):
+    tags = [
+      {'Key': 'heresatag', 'Value': 'heresatagvalue'},
+      {'Key': 'theresatag', 'Value': 'theresatagvalue'},
+      {'Key': 'aws:servicecatalog:provisioningPrincipalArn', 'Value': 'foo/bar'}
+    ]
+    result = utils.format_tags_kv_kp(tags)
+    expected = {
+      "heresatag": "heresatagvalue",
+      "theresatag": "theresatagvalue",
+      "aws:servicecatalog:provisioningPrincipalArn": "foo/bar"
+    }
+    self.assertEqual(result, expected)

--- a/tests/unit/utils/test_get_cnf_stack_tags.py
+++ b/tests/unit/utils/test_get_cnf_stack_tags.py
@@ -1,0 +1,92 @@
+import unittest
+from unittest.mock import MagicMock
+
+import boto3
+import botocore
+from botocore.stub import Stubber
+
+from set_tags import utils
+
+
+class TestGetCfnStackTags(unittest.TestCase):
+
+  def test_valid_stack(self):
+    cfn = utils.get_cfn_client()
+    with Stubber(cfn) as stubber:
+      tags = [
+        {
+          "Key": "aws:servicecatalog:productArn",
+          "Value": "arn:aws:catalog:us-east-1:11111111111:product/prod-6xe6xagbqxb4q"
+        },
+        {
+          "Key": "Project",
+          "Value": "Infrastructure"
+        },
+        {
+          "Key": "aws:servicecatalog:provisioningPrincipalArn",
+          "Value": "arn:aws:sts::11111111111:assumed-role/ServiceCatalogEndusers/273960"
+        },
+        {
+          "Key": "Department",
+          "Value": "Platform"
+        },
+        {
+          "Key": "CostCenter",
+          "Value": "NO PROGRAM / 000000"
+        },
+        {
+          "Key": "aws:servicecatalog:provisioningArtifactIdentifier",
+          "Value": "pa-v5wkshtu5tykw"
+        },
+        {
+          "Key": "aws:servicecatalog:portfolioArn",
+          "Value": "arn:aws:catalog:us-east-1:11111111111:portfolio/port-uk3nkvvmvw64y"
+        },
+        {
+          "Key": "aws:servicecatalog:provisionedProductArn",
+          "Value": "arn:aws:servicecatalog:us-east-1:11111111111:stack/sc306.3/pp-yd5tcochoi32c"
+        }
+      ]
+      response = {
+        "Stacks": [
+          {
+            "StackId": "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-11111111111-pp-yd5tcochoi32c/932c7240-74bc-11ec-9ed8-0ab60a8ca761",
+            "StackName": "SC-11111111111-pp-yd5tcochoi32c",
+            "CreationTime": "2022-01-13T22:03:01.468000+00:00",
+            "LastUpdatedTime": "2022-01-13T22:42:31.079000+00:00",
+            "RollbackConfiguration": {},
+            "StackStatus": "UPDATE_COMPLETE",
+            "DisableRollback": False,
+            "NotificationARNs": [],
+            "Tags": tags
+          }
+        ]
+      }
+      stubber.add_response('describe_stacks', response)
+      utils.get_cfn_client = MagicMock(return_value=cfn)
+      valid_stack_id ='some_reasonable_stack_id'
+      result = utils.get_cfn_stack_tags(valid_stack_id)
+      self.assertEqual(tags, result)
+
+  def test_no_tags(self):
+    cfn = utils.get_cfn_client()
+    with Stubber(cfn) as stubber, self.assertRaises(Exception):
+      response = {
+        "Stacks": [
+          {
+            "StackId": "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-11111111111-pp-yd5tcochoi32c/932c7240-74bc-11ec-9ed8-0ab60a8ca761",
+            "StackName": "SC-11111111111-pp-yd5tcochoi32c",
+            "CreationTime": "2022-01-13T22:03:01.468000+00:00",
+            "LastUpdatedTime": "2022-01-13T22:42:31.079000+00:00",
+            "RollbackConfiguration": {},
+            "StackStatus": "UPDATE_COMPLETE",
+            "DisableRollback": False,
+            "NotificationARNs": [],
+            "Tags": []
+          }
+        ]
+      }
+      stubber.add_response('describe_stacks', response)
+      utils.get_cfn_client = MagicMock(return_value=cfn)
+      valid_stack_id ='some_reasonable_stack_id'
+      result = utils.get_cfn_stack_tags(valid_stack_id)

--- a/tests/unit/utils/test_get_property_value.py
+++ b/tests/unit/utils/test_get_property_value.py
@@ -1,0 +1,67 @@
+import unittest
+
+from set_tags import utils
+
+
+class TestGetPropertyValue(unittest.TestCase):
+
+  def test_get_property_not_found(self):
+
+    with self.assertRaises(ValueError):
+      event = {
+        "RequestType": "Create",
+        "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        "ResponseURL": "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A1111111111%3Astack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9%7CTagInstance%7C3929fbbf-739f-422e-8fce-60766c2cac91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220105T044210Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6L7Q4OWTXJ26R7U6%2F20220105%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=0da97030e5af5ca31d68af3d11d8fdbda814ce013541c4aeaa1866f811414207",
+        "StackId": "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9",
+        "RequestId": "3929fbbf-739f-422e-8fce-60766c2cac91",
+        "LogicalResourceId": "TagInstance",
+        "ResourceType": "Custom::SynapseTagger",
+        "ResourceProperties": {
+          "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        }
+      }
+      result = utils.get_property_value(event, "InstanceId")
+
+  def test_get_property_simple(self):
+    TEST_INSTANCE_ID = 'i-1234567'
+
+    event = {
+      "RequestType": "Create",
+      "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+      "ResponseURL": "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A1111111111%3Astack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9%7CTagInstance%7C3929fbbf-739f-422e-8fce-60766c2cac91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220105T044210Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6L7Q4OWTXJ26R7U6%2F20220105%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=0da97030e5af5ca31d68af3d11d8fdbda814ce013541c4aeaa1866f811414207",
+      "StackId": "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9",
+      "RequestId": "3929fbbf-739f-422e-8fce-60766c2cac91",
+      "LogicalResourceId": "TagInstance",
+      "ResourceType": "Custom::SynapseTagger",
+      "ResourceProperties": {
+        "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        'InstanceId': TEST_INSTANCE_ID
+      }
+    }
+    result = utils.get_property_value(event, "InstanceId")
+    self.assertEqual(result, TEST_INSTANCE_ID)
+
+
+  def test_get_property_complex(self):
+    TEST_BATCH_RESOURCE = {
+      'JobDefinitionArn': 'arn:aws:batch:us-east-1:1111111111:job-definition/SC-465877038949-pp-fyozzocytsz66:6',
+      'JobQueueArn': 'arn:aws:batch:us-east-1:1111111111:job-queue/JobQueue-4f1e8a2180f99b3',
+      'ComputeEnvironmentArn': 'arn:aws:batch:us-east-1:1111111111:compute-environment/ComputeEnvironment-27a5207d7910fd6',
+      'SchedulingPolicyArn': 'arn:aws:batch:us-east-1:1111111111:scheduling-policy/SchedulingPolicy-dazAB1cvtCHfY0RX'
+    }
+
+    event = {
+      "RequestType": "Create",
+      "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+      "ResponseURL": "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A1111111111%3Astack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9%7CTagInstance%7C3929fbbf-739f-422e-8fce-60766c2cac91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220105T044210Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6L7Q4OWTXJ26R7U6%2F20220105%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=0da97030e5af5ca31d68af3d11d8fdbda814ce013541c4aeaa1866f811414207",
+      "StackId": "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9",
+      "RequestId": "3929fbbf-739f-422e-8fce-60766c2cac91",
+      "LogicalResourceId": "TagInstance",
+      "ResourceType": "Custom::SynapseTagger",
+      "ResourceProperties": {
+        "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        'BatchResource': TEST_BATCH_RESOURCE
+      }
+    }
+    result = utils.get_property_value(event, "BatchResource")
+    self.assertEqual(result, TEST_BATCH_RESOURCE)

--- a/tests/unit/utils/test_get_stack_id.py
+++ b/tests/unit/utils/test_get_stack_id.py
@@ -1,0 +1,40 @@
+import unittest
+
+from set_tags import utils
+
+
+class TestGetStackId(unittest.TestCase):
+
+  def test_get_stack_id_not_found(self):
+
+    with self.assertRaises(AssertionError):
+      event = {
+        "RequestType": "Create",
+        "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        "ResponseURL": "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A1111111111%3Astack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9%7CTagInstance%7C3929fbbf-739f-422e-8fce-60766c2cac91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220105T044210Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6L7Q4OWTXJ26R7U6%2F20220105%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=0da97030e5af5ca31d68af3d11d8fdbda814ce013541c4aeaa1866f811414207",
+        "RequestId": "3929fbbf-739f-422e-8fce-60766c2cac91",
+        "LogicalResourceId": "TagInstance",
+        "ResourceType": "Custom::SynapseTagger",
+        "ResourceProperties": {
+          "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+        }
+      }
+      result = utils.get_stack_id(event)
+
+  def test_get_stack_id_value(self):
+    STACK_ID = "arn:aws:cloudformation:us-east-1:1111111111:stack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9"
+
+    event = {
+      "RequestType": "Create",
+      "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+      "ResponseURL": "https://cloudformation-custom-resource-response-useast1.s3.amazonaws.com/arn%3Aaws%3Acloudformation%3Aus-east-1%3A1111111111%3Astack/SC-1111111111-pp-sgs4ci2tpu562/5812d0a0-6de1-11ec-9206-1222684e5ea9%7CTagInstance%7C3929fbbf-739f-422e-8fce-60766c2cac91?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Date=20220105T044210Z&X-Amz-SignedHeaders=host&X-Amz-Expires=7200&X-Amz-Credential=AKIA6L7Q4OWTXJ26R7U6%2F20220105%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Signature=0da97030e5af5ca31d68af3d11d8fdbda814ce013541c4aeaa1866f811414207",
+      "StackId": STACK_ID,
+      "RequestId": "3929fbbf-739f-422e-8fce-60766c2cac91",
+      "LogicalResourceId": "TagInstance",
+      "ResourceType": "Custom::SynapseTagger",
+      "ResourceProperties": {
+        "ServiceToken": "arn:aws:lambda:us-east-1:1111111111:function:cfn-cr-synapse-tagger-SetInstanceTagsFunction-3WJHJ7EN7GG4",
+      }
+    }
+    result = utils.get_stack_id(event)
+    self.assertEqual(result, STACK_ID)


### PR DESCRIPTION
The current implementation of the SetBatchTagsFunction does not work due
to a bug in AWS where the Service Catalog does not apply SC tags to batch
resources.  The SC tags do appear on cloudformation stacks so we
refactor the function to get the SC principal ARN from the
cloudformation stacks instead of the batch resources.

