### PR TITLE
Fix incompatability with pipenv and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,24 @@ repos:
     rev: v2.4.0
     hooks:
     -   id: end-of-file-fixer
+        language_version: python3
     -   id: trailing-whitespace
+        language_version: python3
     -   id: check-ast
+        language_version: python3
 -   repo: https://github.com/adrienverge/yamllint
     rev: v1.19.0
     hooks:
     -   id: yamllint
+        language_version: python3
 -   repo: https://github.com/awslabs/cfn-python-lint
     rev: v0.26.1
     hooks:
     -   id: cfn-python-lint
+        language_version: python3
         files: templates/.*\.(json|yml|yaml)$
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.7
     hooks:
     -   id: remove-tabs
+        language_version: python3


### PR DESCRIPTION
Running pre-commit within a pipenv environment throws the following
error..

```
An unexpected error has occurred: CalledProcessError: command:
  ('/Users/zaro0508/.local/share/virtualenvs/cfn-cr-synapse-tagger-6zgZ7G31/bin/python',
  '-mvirtualenv', '/Users/zaro0508/.cache/pre-commit/repot4hd57p7/py_env-python3.7m', '-p',
  'python3.7m')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7m'

stderr: (none)
Check the log at /Users/zaro0508/.cache/pre-commit/pre-commit.log
```

To fix we set `language_version: python3.7` for all pre-commit hooks

Reference: https://github.com/pre-commit/pre-commit/issues/1375

