### PR TITLE
[IT-4483] Refactor get_synapse_owner_id

### DIFF
--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -107,20 +107,6 @@ def get_env_var_value(env_var):
   return value
 
 def get_synapse_owner_id(tags):
-  '''Find the value of the principal ARN among the resource tags. The principal
-  ARN tag is applied by AWS and it's value should be in the following format
-  'arn:aws:sts::111111111:assumed-role/ServiceCatalogEndusers/1234567'
-  '''
-  principal_arn_tag = 'aws:servicecatalog:provisioningPrincipalArn'
-  for tag in tags:
-    if tag.get('Key') == principal_arn_tag:
-      principal_arn_value = tag.get('Value')
-      synapse_owner_id = principal_arn_value.split('/')[-1]
-      return synapse_owner_id
-  else:
-    raise ValueError(f'Expected to find {principal_arn_tag} in {tags}')
-
-def get_synapse_owner_id(tags):
   '''Find the synapse owner ID from a group of tags. Look for the id from
     'synapse:ownerId' tag first, if not found then look for the
     'aws:servicecatalog:provisioningPrincipalArn' tag (IT-4483).

--- a/set_tags/utils.py
+++ b/set_tags/utils.py
@@ -154,10 +154,10 @@ def get_synapse_owner_id(tags):
   # Case 2: dictionary of key-value pairs
   # tags = {'key1':'value1', 'key2':'value2'}
   elif isinstance(tags, dict):
-    if synapse_owner_id_tag in tags: # Look for synapse:ownerId first
+    if synapse_owner_id_tag in tags:  # Look for synapse:ownerId first
       synapse_owner_id = tags[synapse_owner_id_tag]
       return synapse_owner_id
-    elif principal_arn_tag in tags: # Fallback to aws:servicecatalog:provisioningPrincipalArn
+    elif principal_arn_tag in tags:  # Fallback to aws:servicecatalog:provisioningPrincipalArn
       principal_arn_value = tags[principal_arn_tag]
       synapse_owner_id = principal_arn_value.split('/')[-1]
       return synapse_owner_id

--- a/tests/unit/utils/test_get_synapse_owner_id.py
+++ b/tests/unit/utils/test_get_synapse_owner_id.py
@@ -5,36 +5,56 @@ from set_tags import utils
 
 class TestGetSynapseOwnerId(unittest.TestCase):
 
-  def test_list_tag_present(self):
-    tags = [
-      {'Key': 'heresatag', 'Value': 'heresatagvalue'},
-      {'Key': 'theresatag', 'Value': 'theresatagvalue'},
-      {'Key': 'aws:servicecatalog:provisioningPrincipalArn', 'Value': 'foo/bar'}
-    ]
-    result = utils.get_synapse_owner_id(tags)
-    self.assertEqual(result, 'bar')
-
-  def test_list_tag_missing(self):
-    with self.assertRaises(ValueError):
-      tags = [
-        {'Key': 'heresatag', 'Value': 'heresatagvalue'},
-        {'Key': 'theresatag', 'Value': 'theresatagvalue'}
-      ]
-      utils.get_synapse_owner_id(tags)
-
-  def test_dict_tag_present(self):
-    tags = {
-      'heresatag': 'heresatagvalue',
-      'theresatag':'theresatagvalue',
-      'aws:servicecatalog:provisioningPrincipalArn':'foo/bar'
-    }
-    result = utils.get_synapse_owner_id(tags)
-    self.assertEqual(result, 'bar')
-
-  def test_dict_tag_missing(self):
-    with self.assertRaises(ValueError):
-      tags = {
-        'heresatag': 'heresatagvalue',
-        'theresatag': 'theresatagvalue',
+  def test_dict_with_both_keys(self):
+      data = {
+          "synapse:ownerId": "1234567",
+          "aws:servicecatalog:provisioningPrincipalArn": "arn:aws:sts::111111111:assumed-role/ServiceCatalogEndusers/378505"
       }
-      utils.get_synapse_owner_id(tags)
+      self.assertEqual(utils.get_synapse_owner_id(data), "1234567")
+
+  def test_dict_with_only_owner(self):
+      data = {"synapse:ownerId": "1234567"}
+      self.assertEqual(utils.get_synapse_owner_id(data), "1234567")
+
+  def test_dict_with_only_principal(self):
+      data = {"aws:servicecatalog:provisioningPrincipalArn": "arn:aws:sts::111111111:assumed-role/ServiceCatalogEndusers/378505"}
+      self.assertEqual(
+          utils.get_synapse_owner_id(data),
+          "378505"
+      )
+
+  def test_dict_with_no_keys(self):
+      data = {"foo": "bar"}
+      self.assertIsNone(utils.get_synapse_owner_id(data))
+
+  def test_list_with_both_keys(self):
+      data = [
+          {"Key": "aws:servicecatalog:provisioningPrincipalArn", "Value": "arn:aws:sts::111111111:assumed-role/ServiceCatalogEndusers/378505"},
+          {"Key": "synapse:ownerId", "Value": "1234567"},
+      ]
+      self.assertEqual(utils.get_synapse_owner_id(data), "1234567")
+
+  def test_list_with_only_owner(self):
+      data = [{"Key": "synapse:ownerId", "Value": "1234567"}]
+      self.assertEqual(utils.get_synapse_owner_id(data), "1234567")
+
+  def test_list_with_only_principal(self):
+      data = [{"Key": "aws:servicecatalog:provisioningPrincipalArn", "Value": "arn:aws:sts::111111111:assumed-role/ServiceCatalogEndusers/378505"}]
+      self.assertEqual(
+          utils.get_synapse_owner_id(data),
+          "378505"
+      )
+
+  def test_list_with_no_keys(self):
+      data = [{"Key": "foo", "Value": "bar"}]
+      self.assertIsNone(utils.get_synapse_owner_id(data))
+
+  def test_empty_dict(self):
+      self.assertIsNone(utils.get_synapse_owner_id({}))
+
+  def test_empty_list(self):
+      self.assertIsNone(utils.get_synapse_owner_id([]))
+
+  def test_invalid_type(self):
+      with self.assertRaises(TypeError):
+          utils.get_synapse_owner_id("not a dict or list")


### PR DESCRIPTION
Refactor get_synapse_owner_id method to get the owner ID from both synapse::ownerId and aws:servicecatalog:provisioningPrincipalArn tags with the former as the preferred option and the latter as the fallback option.

This implements the following proposal in IT-4483:
```
For a SC product Updates action the lambda currently also gets the synapse id
from the aws:servicecatalog:provisioningPrincipalArn tag.  We would need to
refactor the lambda to get the synapse id from thesynapse:owerId tag instead.
Then the lambda will generate and apply all of the synapse prefixed tags with the
new owner info. 
```

